### PR TITLE
Add instructions for install from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 [![DOI](https://img.shields.io/badge/DOI-10.1109/ISCMI53840.2021.9654817-blue)](https://doi.org/10.1109/ISCMI53840.2021.9654817)
 [![Fedora package](https://img.shields.io/fedora/v/python3-ast-monitor?color=blue&label=Fedora%20Linux&logo=fedora)](https://src.fedoraproject.org/rpms/python-ast-monitor)
+[![AUR package](https://img.shields.io/aur/version/python-ast-monitor?color=blue&label=Arch%20Linux&logo=arch-linux)](https://aur.archlinux.org/packages/python-ast-monitor)
 
 <p align="center">
   <img width="600" src="https://user-images.githubusercontent.com/73126820/179205064-160bdd44-fd67-4d8d-85dd-badea999885c.png" alt="AST-GUI">
@@ -92,6 +93,12 @@ To install AST-Monitor on Fedora Linux, please use:
 
 ```sh
 $ dnf install python3-ast-monitor
+```
+
+To install AST-Monitor on Arch Linux, please use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers):
+
+```sh
+$ yay -Syyu python-ast-monitor
 ```
 
 ## Deployment


### PR DESCRIPTION
Hi @graysky2 😄. Do you like to port [this package](https://aur.archlinux.org/packages/python-ast-monitor) to alarm if you find nice or useful, like [`python-matplotx`](https://archlinuxarm.org/packages/any/python-matplotx) or [`stressberry`](https://archlinuxarm.org/packages/any/stressberry)