### PR TITLE
WriteLog and Simulation improvements

### DIFF
--- a/ast_monitor/simulation.py
+++ b/ast_monitor/simulation.py
@@ -88,8 +88,7 @@ class Simulation():
                 self.write_hr_to_file(new_rand)
 
     def simulate_gps(self) -> None:
-        f"""
-        GPS simulation.\n
+        """Simulate writing GPS coordinates to file.\n
         Note:
             TCX file 15.tcx was taken from the following dataset:
             S. Rauter, I. Jr. Fister, I. Fister.

--- a/ast_monitor/write_log.py
+++ b/ast_monitor/write_log.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime,timezone
 import time
 
 
@@ -14,7 +14,7 @@ class WriteLog:
             file (str): 
                 path to the log file
         """
-        time_s = datetime.utcnow().isoformat()
+        time_s = datetime.now(timezone.utc).isoformat()
         with open(file, 'a') as log:
             log.write(f'\n[{time_s}] {file}\n')
             log.write('Log parameters: HR_prop, HR_avg, HR_pred, t\n')
@@ -29,7 +29,7 @@ class WriteLog:
             digital_twin (DigitalTwin):
                 the Digital Twin
         """
-        time_s = datetime.utcnow().isoformat()
+        time_s = datetime.now(timezone.utc).isoformat()
         predicted_hr = '-'
         proposed_hr = str(int(digital_twin.proposed_heart_rate))
         average_hr = '-'

--- a/ast_monitor/write_log.py
+++ b/ast_monitor/write_log.py
@@ -11,7 +11,7 @@ class WriteLog:
         """
         Method for writing interval training header.\n
         Args:
-            file: str
+            file (str): 
                 path to the log file
         """
         time_s = datetime.utcnow().isoformat()
@@ -24,9 +24,9 @@ class WriteLog:
         """
         Method for writing interval training trackpoint.\n
         Args:
-            file: str
+            file (str):
                 path to the log file
-            digital_twin: DigitalTwin
+            digital_twin (DigitalTwin):
                 the Digital Twin
         """
         time_s = datetime.utcnow().isoformat()


### PR DESCRIPTION
## WriteLog
I have added the following improvements to the class WriteLog:
- refactor methods write_interval_training_header() and write_interval_training_trackpoint() to remove deprecated methods for timedate.utcnow() and use recommended alternative timedate.now(timezone.utc)
- improvement to documentation

## Simulation
- improvement to documentation