### PR TITLE
Fix wrong page title on start

### DIFF
--- a/ast_monitor/mainwindow.py
+++ b/ast_monitor/mainwindow.py
@@ -1241,8 +1241,9 @@ class Ui_MainWindow(object):
         self.menubar.addAction(self.menuAbout.menuAction())
 
         self.retranslateUi(MainWindow)
-        self.widget_title.setCurrentIndex(0)
         self.stackedWidget.setCurrentIndex(2)
+        self.widget_title.setCurrentIndex(self.stackedWidget.currentIndex())
+        #self.widget_title.setCurrentIndex(0)
         self.swgt_interval_performance.setCurrentIndex(0)
         self.widget_training_data.setCurrentIndex(0)
         self.stackedWidget_2.setCurrentIndex(0)

--- a/ast_monitor/mainwindow.py
+++ b/ast_monitor/mainwindow.py
@@ -1242,8 +1242,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
         self.stackedWidget.setCurrentIndex(2)
-        self.widget_title.setCurrentIndex(self.stackedWidget.currentIndex())
-        #self.widget_title.setCurrentIndex(0)
+        self.widget_title.setCurrentIndex(self.stackedWidget.currentIndex())        
         self.swgt_interval_performance.setCurrentIndex(0)
         self.widget_training_data.setCurrentIndex(0)
         self.stackedWidget_2.setCurrentIndex(0)


### PR DESCRIPTION
Fixes #104.
Essentially, the problem was in the index of the selected page (title).